### PR TITLE
feat: allow `null` or `undefined` to modifiers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,3 @@
-type Modifiers = { [key: string]: boolean; }
-
 const defaults = {
   elementDelimiter: '__',
   modifierDelimiter:  '--',
@@ -30,6 +28,10 @@ export function setup(options: {
   if (typeof options.prefix === 'string') {
     defaults.prefix = options.prefix
   }
+}
+
+type Modifiers = {
+  [key: string]: boolean | null | undefined,
 }
 
 export default function bem(

--- a/test.ts
+++ b/test.ts
@@ -119,6 +119,8 @@ testCases.forEach(({ description, tested, expectations }) => {
     it('returns block with modifier', () => {
       expect(b({ mod1: true })).toBe(expectations[1])
       expect(b({ mod1: true, mod2: false })).toBe(expectations[1])
+      expect(b({ mod1: true, mod2: null })).toBe(expectations[1])
+      expect(b({ mod1: true, mod2: undefined })).toBe(expectations[1])
     })
 
     it('returns block with multiple modifiers', () => {


### PR DESCRIPTION
This change makes sense for TypeScript users.