### PR TITLE
chore: use `linterOptions` in `tslint.json` instead of limited glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "postbuild:esm": "cd dist && uglifyjs bem-ts.js -o bem-ts.min.js --source-map url=bem-ts.min.js.map",
     "test": "nyc tape -r ts-node/register test.ts",
     "test:coverage": "nyc report --reporter=html && opn coverage/index.html",
-    "lint:ts": "tslint \"*.ts\"",
+    "lint:ts": "tslint \"**/*.ts\"",
     "lint:ts:fix": "prettier --write \"**/*.ts\" && npm run lint:ts -- --fix",
     "lint:md": "markdownlint --ignore node_modules --ignore CHANGELOG.md \"**/*.md\"",
     "lint:md:fix": "prettier --write \"**/*.md\"",

--- a/tslint.json
+++ b/tslint.json
@@ -8,5 +8,10 @@
     "interface-over-type-literal": false,
     "no-implicit-dependencies": [true, "dev"],
     "object-literal-sort-keys": false
+  },
+  "linterOptions": {
+    "exclude": [
+      "node_modules/**"
+    ]
   }
 }


### PR DESCRIPTION
TSLint doesn't ignore `node_modules/**` by default.
By using `linterOptions` in `tslint.json`, this makes glob argument more generic.

See <https://github.com/vuejs/vue-cli/issues/1194>

See also #107