### PR TITLE
feat: remove deprecated `prefix` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,20 +110,6 @@ b("element", { mod1: true, mod2: true });
 //=> "block__element block__element--mod1 block__element--mod2"
 ```
 
-### `prefix = ""`
-
-**[DEPRECATED]**: Please use `namespace` and `namespaceDelimiter`.
-
-```ts
-const b = block("block", { prefix: "pre---" });
-
-b();
-//=> "pre---block"
-
-b("element", { mod1: true, mod2: true });
-//=> "pre---block__element pre---block__element--mod1 pre---block__element--mod2"
-```
-
 ### `setup()`
 
 Change default options.

--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,6 @@ const defaults = {
   modifierDelimiter: "--",
   namespace: "",
   namespaceDelimiter: "-",
-  prefix: "",
 };
 
 export function setup(options: {
@@ -11,7 +10,6 @@ export function setup(options: {
   modifierDelimiter?: string;
   namespace?: string;
   namespaceDelimiter?: string;
-  prefix?: string;
 }) {
   if (typeof options.elementDelimiter === "string") {
     defaults.elementDelimiter = options.elementDelimiter;
@@ -24,9 +22,6 @@ export function setup(options: {
   }
   if (typeof options.namespaceDelimiter === "string") {
     defaults.namespaceDelimiter = options.namespaceDelimiter;
-  }
-  if (typeof options.prefix === "string") {
-    defaults.prefix = options.prefix;
   }
 }
 
@@ -41,18 +36,10 @@ export default function bem(
     modifierDelimiter = defaults.modifierDelimiter,
     namespace = defaults.namespace,
     namespaceDelimiter = defaults.namespaceDelimiter,
-    prefix = defaults.prefix,
   } = {}
 ) {
-  if (namespace && prefix) {
-    throw new TypeError(
-      `prefix('${prefix}') is deprecated. Use namespace('${namespace}') instead.`
-    );
-  }
-
   const nsDelim = namespace ? namespaceDelimiter : "";
-  const pre = prefix || `${namespace}${nsDelim}`;
-  const baseBlock = `${pre}${block}`;
+  const baseBlock = `${namespace}${nsDelim}${block}`;
 
   return function bemBlock(elementOrModifiers?: string | Modifiers, modifiers?: Modifiers) {
     let base = baseBlock;

--- a/test.ts
+++ b/test.ts
@@ -75,18 +75,6 @@ const testCases = [
     ],
   },
   {
-    description: "`prefix` option",
-    tested: () => block("block", { prefix: "pre---" }),
-    expectations: [
-      "pre---block",
-      "pre---block pre---block--mod1",
-      "pre---block pre---block--mod1 pre---block--mod2",
-      "pre---block__element",
-      "pre---block__element pre---block__element--mod1",
-      "pre---block__element pre---block__element--mod1 pre---block__element--mod2",
-    ],
-  },
-  {
     description: "`setup()`",
     tested: () => {
       setup({
@@ -152,13 +140,6 @@ testCases.forEach(({ description, tested, expectations }) => {
   });
 });
 
-test("`namespace` and `prefix` at the same time", assert => {
-  const fn = () => block("block", { namespace: "ns", prefix: "pre" });
-  assert.throws(fn, TypeError);
-  assert.throws(fn, "prefix('pre') is deprecated. Use namespace('ns') instead.");
-  assert.end();
-});
-
 // `setup()` test must be at last
 test("`setup()` additional case", t => {
   t.test("overrides options which was setup", assert => {
@@ -178,12 +159,6 @@ test("`setup()` additional case", t => {
       block("block")("element", { mod: true }),
       "ns---block_element ns---block_element-mod"
     );
-    assert.end();
-  });
-
-  t.test("`prefix` option [deprecated]", assert => {
-    setup({ prefix: "pre:", namespace: "" });
-    assert.is(block("block")("element", { mod: true }), "pre:block_element pre:block_element-mod");
     assert.end();
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: remove deprecated `prefix` option

fix #106