### PR TITLE
chore(lint): loosen too strict ESLint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,8 @@
           "travis",
           "sideci",
           "coverage",
-          "security"
+          "security",
+          "lint"
         ]
       ]
     }
@@ -159,6 +160,14 @@
       "plugin:@typescript-eslint/recommended",
       "prettier",
       "prettier/@typescript-eslint"
-    ]
+    ],
+    "rules": {
+      "@typescript-eslint/explicit-function-return-type": [
+        "error",
+        {
+          "allowExpressions": true
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
[`@typescript-eslint/explicit-function-return-type`](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/explicit-function-return-type.md)