### PR TITLE
feat: disallow elements or modifiers including delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ b("element", ["mod1", null, "mod3"]);
 | [`modifierDelimiter`](#modifierdelimiter)   | `string`             | `"--"`  |
 | [`namespace`](#namespace)                   | `string`, `string[]` | `""`    |
 | [`namespaceDelimiter`](#namespacedelimiter) | `string`             | `"-"`   |
+| [`strict`](#strict)                         | `boolean`            | `true`  |
 
 ### `elementDelimiter`
 
@@ -134,6 +135,29 @@ b("element", { mod1: true, mod2: true });
 //=> "block__element block__element--mod1 block__element--mod2"
 ```
 
+### `strict`
+
+When you set `true` to this option, given elements or modifiers are checked.
+And if the check fails, then an runtime error is thrown.
+
+For example, when setting `true`, the following code throws an error.
+
+```ts
+const b = block("foo", { strict: true });
+b("element__");
+b({ modifier--: true });
+```
+
+When setting `false`, the following code throws no errors.
+
+```ts
+const b = block("foo", { strict: false });
+b("element__");
+//=> foo__element__
+b({ modifier_: true });
+//=> foo__modifier_
+```
+
 ### `setup()`
 
 Change default options.
@@ -146,6 +170,7 @@ setup({
   modifierDelimiter: "-",
   namespace: "ns",
   namespaceDelimiter: "---",
+  strict: false,
 });
 
 const b = block("block");

--- a/test.ts
+++ b/test.ts
@@ -106,6 +106,7 @@ const testCases = [
         modifierDelimiter: "-",
         namespace: "ns",
         namespaceDelimiter: "---",
+        strict: true,
       });
       return block("block");
     },
@@ -185,6 +186,37 @@ testCases.forEach(({ description, tested, expectations }) => {
   });
 });
 
+test("invalid arguments", t => {
+  const b = block("invalid", {
+    namespaceDelimiter: "-",
+    elementDelimiter: "__",
+    modifierDelimiter: "--",
+  });
+
+  const expectedError = (subject: string, value: string): RegExp =>
+    new RegExp(
+      `^Error: The ${subject} \\("${value}"\\) must not use the characters contained within the delimiters \\("-", "__", "--"\\)\\.$`
+    );
+
+  t.test("element is invalid", assert => {
+    assert.throws(() => b("element--"), expectedError("element", "element--"));
+    assert.throws(() => b("element_"), expectedError("element", "element_"));
+    assert.throws(() => b("---element"), expectedError("element", "---element"));
+    assert.throws(() => b("-_element"), expectedError("element", "-_element"));
+    assert.throws(() => b("ele-me_nt"), expectedError("element", "ele-me_nt"));
+    assert.end();
+  });
+
+  t.test("modifier is invalid", assert => {
+    assert.throws(() => b(["modifier--"]), expectedError("modifier", "modifier--"));
+    assert.throws(() => b(["modifier_"]), expectedError("modifier", "modifier_"));
+    assert.throws(() => b(["---modifier"]), expectedError("modifier", "---modifier"));
+    assert.throws(() => b(["-_modifier"]), expectedError("modifier", "-_modifier"));
+    assert.throws(() => b(["mod-ifi_er"]), expectedError("modifier", "mod-ifi_er"));
+    assert.end();
+  });
+});
+
 // `setup()` test must be at last
 test("`setup()` additional case", t => {
   t.test("overrides options which was setup", assert => {
@@ -193,8 +225,9 @@ test("`setup()` additional case", t => {
       modifierDelimiter: "/",
       namespace: "n",
       namespaceDelimiter: "=",
+      strict: false,
     });
-    assert.is(b("element", { mod: true }), "n=block:element n=block:element/mod");
+    assert.is(b("element:", { mod: true }), "n=block:element: n=block:element:/mod");
     assert.end();
   });
 


### PR DESCRIPTION
Existing code (e.g. `b("foo-bar")`) can occur errors.
To avoid errors, you can set the option: `strict: false`.

Fix #238 