### PR TITLE
chore: remove useless `npm_install` setting

### DIFF
--- a/sider.yml
+++ b/sider.yml
@@ -1,4 +1,3 @@
 linter:
   eslint:
-    npm_install: "development"
     ext: ".ts"


### PR DESCRIPTION
[skip ci]