### PR TITLE
ci(actions): remove codecov token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,6 @@ jobs:
       - run: npm run build
       - run: npm run release:dry-run
       - uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: wagoid/commitlint-github-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The token is unneeded for public repos.
See https://github.com/codecov/codecov-action