### PR TITLE
fix: add missing `npm ci` before `npm publish`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           node-version: "12"
           registry-url: "https://registry.npmjs.org"
+      - run: npm ci
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This aims to fix the broken publishing automation on the "Release" workflow.