### PR TITLE
fix: add `module` field to package.json for Parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "import": "./dist/index.js",
     "require": "./dist/index.cjs"
   },
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",


### PR DESCRIPTION
Close #892

Parcel's dependency resolution needs some fields in `package.json`. See below:

> `module` – An ES module version of the package.

-- https://parceljs.org/features/dependency-resolution/#package-entries

BTW, the Parcel team has discussed supporting the `exports` field, which is compatible with Node.js. See https://github.com/parcel-bundler/parcel/issues/4155