### PR TITLE
fix: add `main` field to package.json for Parcel

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "require": "./dist/index.cjs"
   },
   "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/",


### PR DESCRIPTION
Fixes the issue where Parcel cannot resolve the commonjs module.