### PR TITLE
docs(readme): improve doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm](https://img.shields.io/npm/v/bem-ts.svg)](https://npm.im/bem-ts)
 [![node](https://img.shields.io/node/v/bem-ts.svg)](https://github.com/ybiquitous/bem-ts)
 
-[BEM](http://getbem.com/) (Block Element Modifier) class names generator for TypeScript.
+[BEM](http://getbem.com/) (_Block Element Modifier_) class names generator for TypeScript.
 
 Inspired by [`bem-cn`](https://npm.im/bem-cn).
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ b("element", ["mod1", null, "mod3"]);
 //=> "block__element block__element--mod1 block__element--mod3"
 ```
 
-A more complex example using React and CSS (nearer to the real world):
+A more complex example using React and CSS (closer to the real world):
 
 ```tsx
 // Button.tsx

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ export function Button({ state, icon, children }: Props) {
 }
 ```
 
-See also the online demo:
+## Demo
 
 [![Edit bem-ts demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/kxymx2r2z5)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install bem-ts
 
 ## Usage
 
-The following is a basic usage.
+A basic usage:
 
 ```typescript
 import bem from "bem-ts";
@@ -53,7 +53,7 @@ b("element", ["mod1", null, "mod3"]);
 //=> "block__element block__element--mod1 block__element--mod3"
 ```
 
-The following is a complicated example (nearer to real world) by using React and CSS.
+A more complex example using React and CSS (nearer to the real world):
 
 ```tsx
 // Button.tsx

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install bem-ts
 
 The following is a basic usage.
 
-```ts
+```typescript
 import bem from "bem-ts";
 
 const b = bem("block");
@@ -53,21 +53,21 @@ b("element", ["mod1", null, "mod3"]);
 //=> "block__element block__element--mod1 block__element--mod3"
 ```
 
-The following is a complicated example (nearer to real world) by using React and Sass.
+The following is a complicated example (nearer to real world) by using React and CSS.
 
 ```tsx
 // Button.tsx
-import * as React from "react";
+import React from "react";
 import bem from "bem-ts";
-import "./Button.scss";
+import "./Button.css";
 
 const b = bem("Button");
 
-interface Props {
+type Props = {
   state: "success" | "danger";
   icon: React.ReactNode;
   children: React.ReactNode;
-}
+};
 
 export function Button({ state, icon, children }: Props) {
   return (
@@ -79,34 +79,29 @@ export function Button({ state, icon, children }: Props) {
 }
 ```
 
-```scss
-// Button.scss
+```css
+/* Button.css */
 .Button {
-  // block styles...
-
-  &--success {
-    // modifier styles...
-  }
-
-  &--danger {
-    // modifier styles...
-  }
-
-  &__icon {
-    // element styles...
-
-    &--success {
-      // element's modifier styles...
-    }
-
-    &--danger {
-      // element's modifier styles...
-    }
-  }
+  /* Block */
+}
+.Button--success {
+  /* Modifier */
+}
+.Button--danger {
+  /* Modifier */
+}
+.Button__icon {
+  /* Element */
+}
+.Button__icon--success {
+  /* Element's modifier */
+}
+.Button__icon--danger {
+  /* Element's modifier */
 }
 ```
 
-See also the online demo below!
+See also the online demo:
 
 [![Edit bem-ts demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/kxymx2r2z5)
 
@@ -114,9 +109,9 @@ See also the online demo below!
 
 ### `bem()`
 
-The `bem()` function receives a block name and creates a new function which generates class names. The created function can receive elements or modifiers.
+The `bem()` function receives a block name and creates a new function that generates class names. The created function can receive elements or modifiers.
 
-The `bem()` function can receive the following options.
+The function can receive the following options:
 
 | Name                                        | Type                 | Default |
 | ------------------------------------------- | -------------------- | ------- |
@@ -128,7 +123,7 @@ The `bem()` function can receive the following options.
 
 #### `elementDelimiter`
 
-```ts
+```typescript
 const b = bem("block", { elementDelimiter: "_" });
 
 b("element");
@@ -137,7 +132,7 @@ b("element");
 
 #### `modifierDelimiter`
 
-```ts
+```typescript
 const b = bem("block", { modifierDelimiter: "-" });
 
 b({ mod: true });
@@ -149,7 +144,7 @@ b("element", { mod: true });
 
 #### `namespace`
 
-```ts
+```typescript
 const b = bem("block", { namespace: "ns" });
 
 b();
@@ -159,7 +154,7 @@ b("element", { mod1: true, mod2: true });
 //=> "ns-block__element ns-block__element--mod1 ns-block__element--mod2"
 ```
 
-```ts
+```typescript
 const b = bem("block", { namespace: ["ns1", "ns2"] });
 
 b();
@@ -171,7 +166,7 @@ b("element", { mod1: true, mod2: true });
 
 #### `namespaceDelimiter`
 
-```ts
+```typescript
 const b = bem("block", { namespace: "ns", namespaceDelimiter: "---" });
 
 b();
@@ -183,7 +178,7 @@ b("element", { mod1: true, mod2: true });
 
 When `namespace` is not given, `namespaceDelimiter` will be ignored.
 
-```ts
+```typescript
 const b = bem("block", { namespaceDelimiter: "---" });
 
 b();
@@ -195,12 +190,11 @@ b("element", { mod1: true, mod2: true });
 
 #### `strict`
 
-When you set `true` to this option, given elements or modifiers are checked.
-And if the check fails, then an runtime error is thrown.
+When you set `true` to this option, given elements or modifiers are checked. And if the check fails, then a runtime error is thrown.
 
 For example, when setting `true`, the following code throws an error.
 
-```ts
+```typescript
 const b = bem("foo", { strict: true });
 b("element__");
 b({ modifier--: true });
@@ -208,7 +202,7 @@ b({ modifier--: true });
 
 When setting `false`, the following code throws no errors.
 
-```ts
+```typescript
 const b = bem("foo", { strict: false });
 b("element__");
 //=> foo__element__
@@ -220,7 +214,7 @@ b({ modifier_: true });
 
 The `setup()` function can change the default options.
 
-```ts
+```typescript
 import bem, { setup } from "bem-ts";
 
 setup({
@@ -236,23 +230,6 @@ const b = bem("block");
 b("element", { mod: true });
 //=> "ns---block_element ns---block_element-mod"
 ```
-
-## Development
-
-### Test
-
-    npm test
-
-When you see a coverage report, execute the following command:
-
-    npm run test:coverage
-
-### Release
-
-On your local machine, execute the following commands:
-
-1.  `npm run release:dry-run`
-2.  `npm run release`
 
 ## License
 


### PR DESCRIPTION
- Replace a SCSS example with a standard CSS one
- Replace syntax indicator `ts` with `typescript` for clarity
- Fix typos
- Remove the redundant `Development` section for most users