### PR TITLE
ci(actions): refactor test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
     needs: test-coverage
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,19 @@ jobs:
       - run: npm --global install npm@latest
       - run: npm ci
       - run: npm run test:coverage
-      - run: npm run posttest # testing build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 1
+
+  upload-coverage:
+    needs: test-coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: coverage
       - uses: codecov/codecov-action@v3
 
   lint:

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
   "scripts": {
     "pretest": "npm run lint",
     "test": "vitest",
-    "test:watch": "npm --ignore-scripts test -- --watch",
-    "test:coverage": "npm --ignore-scripts test -- --coverage",
     "posttest": "npm-run-all --print-label --silent --parallel build build:*",
+    "test:watch": "npm --ignore-scripts test -- --watch",
+    "test:coverage": "npm --ignore-scripts test -- --coverage --watch=false",
+    "posttest:coverage": "npm run posttest",
     "build": "tsc",
     "build:cjs": "tsc --project tsconfig.cjs.json && mv dist/cjs/index.js dist/index.cjs && rm -rf dist/cjs/",
     "lint:js": "eslint --cache --ext=js,jsx,cjs,mjs,ts,tsx .",


### PR DESCRIPTION
This splits a new job uploading coverage to minimize effects from the 3rd-party service (CodeCov).
See https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow
