### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,13 +91,13 @@
       "dev": true
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.5.tgz",
-      "integrity": "sha512-3PQrWr/uo6lzF5k7n5QuosCYnzaxP9qGBp3jhWP0Vmsa7XA6wrl9ccPqfQyXpSbQE3zBROVO3TDqgPKe4tfmLQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.6.tgz",
+      "integrity": "sha512-sTKpr2i/Fjs9OmhU+beBxjPavpnLSqZaO6CzwKVq2Tc4UYVTMFgpKOslDhUBVlfAUBfjVO8ParxC/MXkIOevEA==",
       "dev": true,
       "dependencies": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.6.5",
+        "@commitlint/lint": "^17.6.6",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -290,22 +290,22 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.5.tgz",
-      "integrity": "sha512-CQvAPt9gX7cuUbMrIaIMKczfWJqqr6m8IlJs0F2zYwyyMTQ87QMHIj5jJ5HhOaOkaj6dvTMVGx8Dd1I4xgUuoQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.6.tgz",
+      "integrity": "sha512-4Fw875faAKO+2nILC04yW/2Vy/wlV3BOYCSQ4CEFzriPEprc1Td2LILmqmft6PDEK5Sr14dT9tEzeaZj0V56Gg==",
       "dev": true,
       "dependencies": {
         "@commitlint/types": "^17.4.4",
-        "semver": "7.5.0"
+        "semver": "7.5.2"
       },
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/is-ignored/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -318,12 +318,12 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.5.tgz",
-      "integrity": "sha512-BSJMwkE4LWXrOsiP9KoHG+/heSDfvOL/Nd16+ojTS/DX8HZr8dNl8l3TfVr/d/9maWD8fSegRGtBtsyGuugFrw==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.6.tgz",
+      "integrity": "sha512-5bN+dnHcRLkTvwCHYMS7Xpbr+9uNi0Kq5NR3v4+oPNx6pYXt8ACuw9luhM/yMgHYwW0ajIR20wkPAFkZLEMGmg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^17.6.5",
+        "@commitlint/is-ignored": "^17.6.6",
         "@commitlint/parse": "^17.6.5",
         "@commitlint/rules": "^17.6.5",
         "@commitlint/types": "^17.4.4"
@@ -1048,9 +1048,9 @@
       "dev": true
     },
     "node_modules/@eslint/js": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
-      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4178,15 +4178,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
-      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.42.0",
+        "@eslint/js": "8.43.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -12155,13 +12155,13 @@
       "dev": true
     },
     "@commitlint/cli": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.5.tgz",
-      "integrity": "sha512-3PQrWr/uo6lzF5k7n5QuosCYnzaxP9qGBp3jhWP0Vmsa7XA6wrl9ccPqfQyXpSbQE3zBROVO3TDqgPKe4tfmLQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.6.6.tgz",
+      "integrity": "sha512-sTKpr2i/Fjs9OmhU+beBxjPavpnLSqZaO6CzwKVq2Tc4UYVTMFgpKOslDhUBVlfAUBfjVO8ParxC/MXkIOevEA==",
       "dev": true,
       "requires": {
         "@commitlint/format": "^17.4.4",
-        "@commitlint/lint": "^17.6.5",
+        "@commitlint/lint": "^17.6.6",
         "@commitlint/load": "^17.5.0",
         "@commitlint/read": "^17.5.1",
         "@commitlint/types": "^17.4.4",
@@ -12307,19 +12307,19 @@
       }
     },
     "@commitlint/is-ignored": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.5.tgz",
-      "integrity": "sha512-CQvAPt9gX7cuUbMrIaIMKczfWJqqr6m8IlJs0F2zYwyyMTQ87QMHIj5jJ5HhOaOkaj6dvTMVGx8Dd1I4xgUuoQ==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.6.6.tgz",
+      "integrity": "sha512-4Fw875faAKO+2nILC04yW/2Vy/wlV3BOYCSQ4CEFzriPEprc1Td2LILmqmft6PDEK5Sr14dT9tEzeaZj0V56Gg==",
       "dev": true,
       "requires": {
         "@commitlint/types": "^17.4.4",
-        "semver": "7.5.0"
+        "semver": "7.5.2"
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+          "version": "7.5.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+          "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -12328,12 +12328,12 @@
       }
     },
     "@commitlint/lint": {
-      "version": "17.6.5",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.5.tgz",
-      "integrity": "sha512-BSJMwkE4LWXrOsiP9KoHG+/heSDfvOL/Nd16+ojTS/DX8HZr8dNl8l3TfVr/d/9maWD8fSegRGtBtsyGuugFrw==",
+      "version": "17.6.6",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.6.6.tgz",
+      "integrity": "sha512-5bN+dnHcRLkTvwCHYMS7Xpbr+9uNi0Kq5NR3v4+oPNx6pYXt8ACuw9luhM/yMgHYwW0ajIR20wkPAFkZLEMGmg==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^17.6.5",
+        "@commitlint/is-ignored": "^17.6.6",
         "@commitlint/parse": "^17.6.5",
         "@commitlint/rules": "^17.6.5",
         "@commitlint/types": "^17.4.4"
@@ -12768,9 +12768,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.42.0.tgz",
-      "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.43.0.tgz",
+      "integrity": "sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -15045,15 +15045,15 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.42.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.42.0.tgz",
-      "integrity": "sha512-ulg9Ms6E1WPf67PHaEY4/6E2tEn5/f7FXGzr3t9cBMugOmf1INYvuUwwh1aXQN4MfJ6a5K2iNwP3w4AColvI9A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.43.0.tgz",
+      "integrity": "sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
         "@eslint/eslintrc": "^2.0.3",
-        "@eslint/js": "8.42.0",
+        "@eslint/js": "8.43.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",


### PR DESCRIPTION
This pull request fixes the vulnerable packages via npm [9.7.2](https://github.com/npm/cli/releases/tag/v9.7.2).

<details open>
<summary><strong>Updated (6)</strong></summary>

| Package | Version | Source | Detail |
|:--------|:-------:|:------:|:-------|
| [@commitlint/cli](https://www.npmjs.com/package/@commitlint/cli/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/is-ignored](https://www.npmjs.com/package/@commitlint/is-ignored/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@commitlint/lint](https://www.npmjs.com/package/@commitlint/lint/v/17.6.6) | `17.6.5` → `17.6.6` | [github](https://github.com/conventional-changelog/commitlint) | - |
| [@eslint/js](https://www.npmjs.com/package/@eslint/js/v/8.43.0) | `8.42.0` → `8.43.0` | [github](https://github.com/eslint/eslint) | - |
| [eslint](https://www.npmjs.com/package/eslint/v/8.43.0) | `8.42.0` → `8.43.0` | [github](https://github.com/eslint/eslint) | - |
| [semver](https://www.npmjs.com/package/semver/v/7.5.2) (`@commitlint/is-ignored/node_modules/semver`) | `7.5.0` → `7.5.2` | [github](https://github.com/npm/node-semver) | **[Moderate]** semver vulnerable to Regular Expression Denial of Service ([ref](https://github.com/advisories/GHSA-c2qf-rxjj-qqgw)) |

</details>

***

Created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action)