### PR TITLE
ci(actions): revise codecov token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           name: coverage
       - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     uses: ybiquitous/.github/.github/workflows/nodejs-lint-reusable.yml@main


### PR DESCRIPTION
Codecov Action v4 doesn't support tokenless uploading. See https://github.com/codecov/codecov-action#v4-release

See also #462