### PR TITLE
feat!: drop Node.js 14 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["14", "16", "18", "20"]
+        node-version: ["16", "18", "20"]
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "ybiq": "^16.3.1"
       },
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "!*test*"
   ],
   "engines": {
-    "node": "^14.13.1 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
Node.js 14 reached End-of-Life.
Ref https://github.com/nodejs/Release#release-schedule
