### PR TITLE
chore(deps): temporarily disable ESLint major updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     groups:
       dev-deps:
         dependency-type: development
+    ignore:
+      - dependency-name: eslint # TODO: Temporarily disable due to some plugins has unsupported ESLint v9.
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
See CI failures in #1012.