### PR TITLE
chore: replace deprecated `@tsconfig/node16-strictest-esm` with other `@tsconfig/*` packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
-        "@tsconfig/node16-strictest-esm": "^1.0.3",
+        "@tsconfig/node16": "^16.1.3",
+        "@tsconfig/strictest": "^2.0.5",
         "@types/node": "^22.5.1",
         "@typescript-eslint/eslint-plugin": "^8.3.0",
         "@vitest/coverage-v8": "^2.0.5",
@@ -1913,11 +1914,19 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@tsconfig/node16-strictest-esm": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest-esm/-/node16-strictest-esm-1.0.3.tgz",
-      "integrity": "sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==",
-      "dev": true
+    "node_modules/@tsconfig/node16": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.3.tgz",
+      "integrity": "sha512-9nTOUBn+EMKO6rtSZJk+DcqsfgtlERGT9XPJ5PRj/HNENPCBY1yu/JEj5wT6GLtbCLBO2k46SeXDaY0pjMqypw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/strictest": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.5.tgz",
+      "integrity": "sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/concat-stream": {
       "version": "2.0.0",
@@ -15019,10 +15028,16 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "@tsconfig/node16-strictest-esm": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16-strictest-esm/-/node16-strictest-esm-1.0.3.tgz",
-      "integrity": "sha512-0/QTPDkKmE2dy0dMRstPCv4VJ+gUGgvMKzaWd5P3hgdlmPqYqe1pJxDGUlNYbSgUBlncIvvX+mIeZarokysNgg==",
+    "@tsconfig/node16": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-16.1.3.tgz",
+      "integrity": "sha512-9nTOUBn+EMKO6rtSZJk+DcqsfgtlERGT9XPJ5PRj/HNENPCBY1yu/JEj5wT6GLtbCLBO2k46SeXDaY0pjMqypw==",
+      "dev": true
+    },
+    "@tsconfig/strictest": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@tsconfig/strictest/-/strictest-2.0.5.tgz",
+      "integrity": "sha512-ec4tjL2Rr0pkZ5hww65c+EEPYwxOi4Ryv+0MtjeaSQRJyq322Q27eOQiFbuNgw2hpL4hB1/W/HBGk3VKS43osg==",
       "dev": true
     },
     "@types/concat-stream": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "prepublishOnly": "npm run posttest"
   },
   "devDependencies": {
-    "@tsconfig/node16-strictest-esm": "^1.0.3",
+    "@tsconfig/node16": "^16.1.3",
+    "@tsconfig/strictest": "^2.0.5",
     "@types/node": "^22.5.1",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@vitest/coverage-v8": "^2.0.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
-  "extends": "@tsconfig/node16-strictest-esm/tsconfig.json",
+  "extends": ["@tsconfig/strictest/tsconfig", "@tsconfig/node16/tsconfig"],
   "compilerOptions": {
+    "module": "es2022",
+    "moduleResolution": "node10",
     "declaration": true,
-    "outDir": "./dist/",
-    "ignoreDeprecations": "5.0"
+    "outDir": "./dist/"
   },
   "files": ["index.ts"]
 }


### PR DESCRIPTION
Ref https://www.npmjs.com/package/@tsconfig/node16-strictest-esm
