### PR TITLE
feat!: drop Node.js 16 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["16", "18", "20", "22"]
+        node-version: ["18", "20", "22"]
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "ybiq": "^17.4.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "!*test*"
   ],
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
Node.js 16 already reached EOL.
Ref https://github.com/nodejs/Release#release-schedule
