### PR TITLE
feat!: drop Node.js 18 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["18", "20", "22"]
+        node-version: ["20", "22", "24"]
     uses: ybiquitous/.github/.github/workflows/nodejs-test-reusable.yml@main
     with:
       node-version: ${{ matrix.node-version }}
-      node-version-coverage: "20"
+      node-version-coverage: "24"
 
   upload-coverage:
     needs: test

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "ybiq": "^18.0.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "!*test*"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
Node.js 18 is already EOL.
https://github.com/nodejs/Release#release-schedule
