### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5740,9 +5740,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -5758,6 +5758,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12720,9 +12721,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.11",


### PR DESCRIPTION
This pull request fixes the vulnerable packages via [npm v11.13.0](https://github.com/npm/cli/releases/tag/v11.13.0).

<details open>
<summary><strong>Updated (1)</strong></summary>

| Package | Version | Source | Severity | Link |
|:--------|:-------:|:------:|:--------:|:-----|
| [postcss](https://www.npmjs.com/package/postcss/v/8.5.12) | `8.5.9`→`8.5.12` | [github](https://github.com/postcss/postcss) | **Moderate** | <https://github.com/advisories/GHSA-qx2v-qp2m-jg93> |

</details>

This pull request was created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action) in the [action run](https://github.com/ybiquitous/bem-ts/actions/runs/24971387605).