### PR TITLE
build(deps): npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3841,10 +3841,20 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -11469,9 +11479,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"


### PR DESCRIPTION
This pull request fixes the vulnerable packages via [npm v11.17.0](https://github.com/npm/cli/releases/tag/v11.17.0).

<details open>
<summary><strong>Updated (1)</strong></summary>

| Package | Version | Source | Severity | Link |
|:--------|:-------:|:------:|:--------:|:-----|
| [js-yaml](https://www.npmjs.com/package/js-yaml/v/4.3.0) | `4.1.1`→`4.3.0` | [github](https://github.com/nodeca/js-yaml) | **Moderate** | <https://github.com/advisories/GHSA-h67p-54hq-rp68> |

</details>

This pull request was created by [ybiquitous/npm-audit-fix-action](https://github.com/ybiquitous/npm-audit-fix-action) in the [action run](https://github.com/ybiquitous/bem-ts/actions/runs/28307057539).